### PR TITLE
Fixed bug for encoding value

### DIFF
--- a/src/ts/forwarders/proxyAccountFowarder.ts
+++ b/src/ts/forwarders/proxyAccountFowarder.ts
@@ -51,7 +51,7 @@ export class ProxyAccountForwarder extends Forwarder<ProxyAccountCallData> {
     // ProxyAccounts have a "value" field.
     return defaultAbiCoder.encode(
       ["address", "uint", "bytes"],
-      [data.to, data.value, data.data]
+      [data.to, data.value ? data.value : 0, data.data]
     );
   }
 


### PR DESCRIPTION
We decided to omit the need for "value" in ProxyAccountCallData. But this broke some of the signing code. Fixed here alongside a test. 