### PR TITLE
Add rinkeby and kovan testnets

### DIFF
--- a/gnosisSafe.md
+++ b/gnosisSafe.md
@@ -19,9 +19,11 @@ import { ChainID } from "@anydotcrypto/metatransactions";
 Our library currently supports MAINNET or ROPSTEN.
 
 ```
-// Blockchain ID (Mainnet = 3)
+// Blockchain ID (Mainnet = 1)
 ChainID.MAINNET;
 ChainID.ROPSTEN;
+ChainID.RINKEBY;
+ChainID.KOVAN;
 ```
 
 The Gnosis Safe library only supports NONCE replay protection. Check out our [wallet contracts](proxyAccounts) for more exotic replay protection.

--- a/proxyAccounts.md
+++ b/proxyAccounts.md
@@ -19,9 +19,11 @@ import { ChainID, ReplayProtectionType } from "@anydotcrypto/metatransactions";
 Our library currently supports MAINNET or ROPSTEN.
 
 ```
-// Blockchain ID (Mainnet = 3)
+// Blockchain ID (Mainnet = 1)
 ChainID.MAINNET;
 ChainID.ROPSTEN;
+ChainID.RINKEBY;
+ChainID.KOVAN;
 ```
 
 Our library has three types of replay protection (and more in-depth information can be [found here](https://github.com/PISAresearch/metamask-comp)):

--- a/src/ts/forwarders/forwarderFactory.ts
+++ b/src/ts/forwarders/forwarderFactory.ts
@@ -11,6 +11,8 @@ export enum ReplayProtectionType {
 export enum ChainID {
   MAINNET = 1,
   ROPSTEN = 3,
+  RINKEBY = 4,
+  KOVAN = 42,
 }
 
 export enum ForwarderType {


### PR DESCRIPTION
Added IDs for kovan and rinkeby.
Contracts already deployed.